### PR TITLE
Migrate Prettier configuration to JavaScript module format

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,0 @@
-{
-  "semi": true,
-  "tabWidth": 2,
-  "printWidth": 100,
-  "singleQuote": true,
-  "trailingComma": "es5",
-  "bracketSpacing": true,
-  "htmlWhitespaceSensitivity": "css"
-}

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,14 @@
+/**
+ * @type {import('prettier').Config}
+ */
+const config = {
+  semi: true,
+  tabWidth: 2,
+  printWidth: 100,
+  singleQuote: true,
+  trailingComma: 'es5',
+  bracketSpacing: true,
+  htmlWhitespaceSensitivity: 'css',
+};
+
+export default config;


### PR DESCRIPTION
- Switched to ES module format for better compatibility with modern tooling
- Maintained the same formatting rules for consistency